### PR TITLE
Fix: 비로그인 사용자의 대역어 순서 변경 방지 및 보안 강화

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,13 @@ export default function Home() {
     } catch (error) {
       console.error("Error updating translation preference:", error);
       toast.error("변경 사항을 저장하지 못했습니다.");
-      // Rollback logic would go here
+
+      // Rollback
+      setResults((prev) => {
+        const newResults = [...prev];
+        newResults[termIndex] = term; // Restore original term
+        return newResults;
+      });
     }
   };
 
@@ -160,6 +166,7 @@ export default function Home() {
   );
 
   const handleDragEnd = async (event: DragEndEvent, termId: number) => {
+    if (!session) return;
     const { active, over } = event;
 
     if (!over || active.id === over.id) {
@@ -201,6 +208,13 @@ export default function Home() {
     } catch (error) {
       console.error("Error updating sort order:", error);
       toast.error("순서 저장에 실패했습니다.");
+
+      // Rollback
+      setResults((prev) => {
+        const newResults = [...prev];
+        newResults[termIndex] = term; // Restore original term
+        return newResults;
+      });
     }
   };
 

--- a/src/components/SortableBadge.tsx
+++ b/src/components/SortableBadge.tsx
@@ -33,7 +33,12 @@ export function SortableBadge({
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...(isSessionActive ? listeners : {})}
+    >
       <Badge
         variant={translation.is_preferred ? "default" : "secondary"}
         className={`text-sm py-1 px-3 transition-all select-none ${
@@ -45,7 +50,7 @@ export function SortableBadge({
             ? "bg-green-600 hover:bg-green-700"
             : "bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
         }`}
-        onClick={onClick}
+        onClick={isSessionActive ? onClick : undefined}
       >
         {translation.text}
         {translation.is_preferred && <Check className="w-3 h-3 ml-1" />}

--- a/supabase/migrations/20241208000001_restrict_policies.sql
+++ b/supabase/migrations/20241208000001_restrict_policies.sql
@@ -1,0 +1,43 @@
+-- Drop permissive policies
+drop policy "Allow anon insert on Term" on public."Term";
+drop policy "Allow update on Term" on public."Term";
+drop policy "Allow delete on Term" on public."Term";
+
+drop policy "Allow anon insert on Translation" on public."Translation";
+drop policy "Allow update on Translation" on public."Translation";
+drop policy "Allow delete on Translation" on public."Translation";
+
+-- Create restricted policies (Authenticated users only)
+-- Term
+create policy "Allow authenticated insert on Term"
+  on public."Term" for insert
+  to authenticated
+  with check (true);
+
+create policy "Allow authenticated update on Term"
+  on public."Term" for update
+  to authenticated
+  using (true)
+  with check (true);
+
+create policy "Allow authenticated delete on Term"
+  on public."Term" for delete
+  to authenticated
+  using (true);
+
+-- Translation
+create policy "Allow authenticated insert on Translation"
+  on public."Translation" for insert
+  to authenticated
+  with check (true);
+
+create policy "Allow authenticated update on Translation"
+  on public."Translation" for update
+  to authenticated
+  using (true)
+  with check (true);
+
+create policy "Allow authenticated delete on Translation"
+  on public."Translation" for delete
+  to authenticated
+  using (true);


### PR DESCRIPTION
# Bug Fix: 비로그인 사용자 대역어 순서 변경 방지

Resolves #6.

## 문제 상황
- 로그인하지 않은 사용자도 대역어를 클릭하거나 드래그하여 순서를 변경할 수 있는 문제가 있었습니다.
- UI는 낙관적 업데이트로 인해 변경된 것처럼 보였고, RLS 정책이 허술하여 실제로 DB 업데이트가 가능했을 수도 있습니다 (초기 정책).

## 해결 방법
### 1. DB 보안 강화 (RLS)
- `Translation` 테이블에 대한 `UPDATE`, `INSERT`, `DELETE` 권한을 **Authenticated User(로그인 유저)**에게만 허용하도록 정책을 수정했습니다.
- 이제 토큰 없이 API를 호출하면 `400/403` 에러가 발생합니다.

### 2. UI/UX 개선
- **드래그 앤 드롭 비활성화**: 로그인 세션이 없으면 `SortableBadge`에 드래그 리스너와 클릭 핸들러가 아예 부착되지 않도록 수정했습니다.
- **예외 처리 및 자동 원복(Rollback)**: 낙관적 업데이트(Optimistic Update) 후 서버 요청이 실패할 경우, 변경 사항을 즉시 원래대로 되돌리는 로직을 추가했습니다.
  - 이로 인해 혹시라도 UI가 변경되더라도 즉시 에러 메시지와 함께 원복되어 사용자 혼란을 방지합니다.

## 테스트
- Guest Mode에서 클릭/드래그 시 동작하지 않음 확인.
- 강제 API 호출 시 차단됨 확인.
