### PR TITLE
fix: Supabase DB 깨우기 작업 이름 변경 및 요청 수정

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -10,7 +10,8 @@ jobs:
   ping-supabase:
     runs-on: ubuntu-latest
     steps:
-      - name: Ping Supabase URL
+      - name: Wake up Supabase DB
         run: |
-          curl -I -X GET "${{ secrets.SUPABASE_URL }}/rest/v1/" \
-          -H "apikey: ${{ secrets.SUPABASE_KEY }}"
+          curl -X GET "${{ secrets.SUPABASE_URL }}/rest/v1/Term?select=*&limit=1" \
+          -H "apikey: ${{ secrets.SUPABASE_KEY }}" \
+          -H "Authorization: Bearer ${{ secrets.SUPABASE_KEY }}"  


### PR DESCRIPTION
- 작업 이름을 "Wake up Supabase DB"로 변경하여 더 명확하게 표현
- Supabase DB를 깨우기 위한 GET 요청에 적절한 헤더 추가 및 쿼리 수정
  - 실제 테이블에서 데이터를 요청하도록 변경하여 DB가 활성화되도록 함